### PR TITLE
Fixing Tests + Changing default tokenURI behavior with baseURI 

### DIFF
--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -11,25 +11,33 @@ contract ERC721Test is DSTestPlus {
     MockERC721 token;
 
     function setUp() public {
-        token = new MockERC721("Token", "TKN");
+        token = new MockERC721("Token", "TKN", "ipfs://somehash/");
     }
 
     function invariantMetadata() public {
         assertEq(token.name(), "Token");
         assertEq(token.symbol(), "TKN");
+        assertEq(token.baseURI(), "ipfs://somehash/");
     }
 
-    function testMetadata(string memory name, string memory symbol) public {
+    function testMetadata(string memory name, string memory symbol, string memory baseURI) public {
         MockERC721 tkn = new MockERC721(name, symbol);
         assertEq(tkn.name(), name);
         assertEq(tkn.symbol(), symbol);
+        assertEq(tkn.baseURI(), baseURI);
     }
 
     function proveMint(address usr, uint256 tokenId) public {
-        token.mint(usr, tokenId, "");
+        token.mint(usr, tokenId);
 
         assertEq(token.totalSupply(), tokenId);
         assertEq(token.balanceOf(usr), tokenId);
+    }
+
+    function proveTokenURI(address usr, uint256 tokenId) public {
+        token.mint(usr, tokenId);
+
+        assertEq(token.tokenURI(tokenId), abi.encodePacked(token.baseURI(), tokenURI(tokenId)));
     }
 
     function proveBurn(
@@ -41,7 +49,7 @@ contract ERC721Test is DSTestPlus {
         if (tokenIds1.length > tokenIds0.length) return;
 
         for (uint256 i = 0; i < tokenIds1.length; i++) {
-            token.mint(usr, tokenIds1[i], "");
+            token.mint(usr, tokenIds1[i]);
         }
 
         for (uint256 i = 0; i < tokenIds0.length; i++) {
@@ -59,7 +67,7 @@ contract ERC721Test is DSTestPlus {
     }
 
     function proveTransfer(address usr, uint256 tokenId) public {
-        token.mint(msg.sender, tokenId, "");
+        token.mint(msg.sender, tokenId);
 
         assertTrue(token.transfer(usr, tokenId));
         assertEq(token.totalSupply(), tokenId);
@@ -83,7 +91,7 @@ contract ERC721Test is DSTestPlus {
         ERC721User src = new ERC721User(token);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            token.mint(address(src), tokenIds[i], "");
+            token.mint(address(src), tokenIds[i]);
         }
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
@@ -122,7 +130,7 @@ contract ERC721Test is DSTestPlus {
         ERC721User src = new ERC721User(token);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            token.mint(address(src), tokenIds[i], "");
+            token.mint(address(src), tokenIds[i]);
         }
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
@@ -162,7 +170,7 @@ contract ERC721Test is DSTestPlus {
         ERC721User src = new ERC721User(token);
 
         for (uint256 i = 0; i < tokenIds.length; i++) {
-            token.mint(address(src), tokenIds[i], "");
+            token.mint(address(src), tokenIds[i]);
         }
 
         for (uint256 i = 0; i < tokenIds.length; i++) {

--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -51,6 +51,14 @@ contract ERC721Test is DSTestPlus {
         assertBytesEq(bytes(token.tokenURI(tokenId)), abi.encodePacked(token.baseURI(), tokenId));
     }
 
+    function testBurnInexistentToken(uint256 tokenId) public {
+        try token.burn(tokenId) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, "NOT_MINTED");
+        }
+    }
+
     function testBurn(
         address usr,
         uint256[] calldata tokenIds,

--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -35,6 +35,18 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.ownerOf(tokenId), usr);
     }
 
+    function testMintSameToken(address usr, uint256 tokenId) public {
+        if (usr == address(0)) return;
+
+        token.mint(usr, tokenId);
+
+        try token.mint(usr, tokenId) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, "ALREADY_MINTED");
+        }
+    }
+
     function testTokenURI(uint256 tokenId) public {
         assertBytesEq(bytes(token.tokenURI(tokenId)), abi.encodePacked(token.baseURI(), tokenId));
     }

--- a/src/test/ERC721.t.sol
+++ b/src/test/ERC721.t.sol
@@ -80,10 +80,70 @@ contract ERC721Test is DSTestPlus {
         assertEq(token.balanceOf(usr), tokenIds.length - burnCount);
     }
 
-    function testApprove(address usr, uint256 tokenId) public {
-        //assertTrue(token.approve(usr, tokenId));
+    function testSafeTransferFromWithApprove(uint256 tokenId) public {
+        ERC721User usr = new ERC721User(token);
+        ERC721User receiver = new ERC721User(token);
+        ERC721User operator = new ERC721User(token);
 
-        //assertEq(token.isApprovedForAll(msg.sender, usr, tokenId));
+        // first mint a token
+        token.mint(address(usr), tokenId);
+
+        // The operator should not be able to transfer the unapproved token
+        try operator.safeTransferFrom(address(usr), address(receiver), tokenId) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, "NOT_APPROVED");
+        }
+
+        // then approve an operator for the token
+        usr.approve(address(operator), tokenId);
+
+        // The operator should be able to transfer the approved token
+        operator.safeTransferFrom(address(usr), address(receiver), tokenId);
+        assertEq(token.balanceOf(address(usr)), 0);
+        assertEq(token.balanceOf(address(receiver)), 1);
+        assertEq(token.ownerOf(tokenId), address(receiver));
+
+        // The operator now should not be able to transfer the token again
+        // since it was not approved by the current user
+        try operator.safeTransferFrom(address(receiver), address(usr), tokenId) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, "NOT_APPROVED");
+        }
+    }
+
+    function testSafeTransferFromWithApproveForAll(uint256 tokenId) public {
+        ERC721User usr = new ERC721User(token);
+        ERC721User receiver = new ERC721User(token);
+        ERC721User operator = new ERC721User(token);
+
+        // first mint two tokens, only one will be approved
+        token.mint(address(usr), tokenId);
+
+        // The operator should not be able to transfer the unapproved token
+        try operator.safeTransferFrom(address(usr), address(receiver), tokenId) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, "NOT_APPROVED");
+        }
+
+        // then approve an operator
+        usr.setApprovalForAll(address(operator), true);
+
+        // The operator should be able to transfer any token from usr
+        operator.safeTransferFrom(address(usr), address(receiver), tokenId);
+        assertEq(token.balanceOf(address(usr)), 0);
+        assertEq(token.balanceOf(address(receiver)), 1);
+        assertEq(token.ownerOf(tokenId), address(receiver));
+
+        // The operator now should not be able to transfer the token 
+        // since it was not approved by the current user
+        try operator.safeTransferFrom(address(receiver), address(usr), tokenId) {
+            fail();
+        } catch Error(string memory error) {
+            assertEq(error, "NOT_APPROVED");
+        }
     }
 
     function testTransfer(address usr, uint256 tokenId) public {
@@ -99,127 +159,6 @@ contract ERC721Test is DSTestPlus {
             assertEq(token.balanceOf(address(this)), 0);
             assertEq(token.balanceOf(usr), 1);
             assertEq(token.ownerOf(tokenId), usr);
-        }
-    }
-
-    function testTransferFrom(
-        address dst,
-        uint256[] calldata tokenIds,
-        uint8 approvalCount
-    ) public {
-        // dst must approve this for more than tokenIds.length
-        if (tokenIds.length < approvalCount) return;
-        if(dst == address(0)) return;
-
-        ERC721User src = new ERC721User(token);
-
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            token.mint(address(src), tokenIds[i]);
-        }
-
-        for (uint256 i = 0; i < approvalCount; i++) {
-            src.approve(address(this), tokenIds[i]);
-            token.transferFrom(address(src), dst, tokenIds[i]);
-        }
-
-        assertEq(token.totalSupply(), tokenIds.length);
-
-        //uint256 app = address(src) == msg.sender || approvals == type(uint256).max ? approvals : approvals - tokenIds;
-        //assertEq(token.allowance(address(src), msg.sender), app);
-
-        if (address(src) == dst) {
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                assertEq(token.ownerOf(tokenIds[i]), address(src));
-            }
-        } else {
-            assertEq(token.balanceOf(address(src)), tokenIds.length - approvalCount);
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                if(i < approvalCount)
-                    assertEq(token.ownerOf(tokenIds[i]), dst);
-                else
-                    assertEq(token.ownerOf(tokenIds[i]), address(src));
-            }
-        }
-    }
-
-    function testSafeTransferFrom(
-        address dst,
-        uint256[] calldata tokenIds,
-        uint8 approvalCount
-    ) public {
-        // dst must approve this for more than tokenIds.length
-        if (tokenIds.length < approvalCount) return;
-        if(dst == address(0)) return;
-
-        ERC721User src = new ERC721User(token);
-
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            token.mint(address(src), tokenIds[i]);
-        }
-
-        for (uint256 i = 0; i < approvalCount; i++) {
-            src.approve(address(this), tokenIds[i]);
-            token.safeTransferFrom(address(src), dst, tokenIds[i]);
-        }
-
-        assertEq(token.totalSupply(), tokenIds.length);
-
-        //uint256 app = address(src) == msg.sender || approvals == type(uint256).max ? approvals : approvals - tokenIds;
-        //assertEq(token.allowance(address(src), msg.sender), app);
-
-        if (address(src) == dst) {
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                assertEq(token.ownerOf(tokenIds[i]), address(src));
-            }
-        } else {
-            assertEq(token.balanceOf(address(src)), tokenIds.length - approvalCount);
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                if(i < approvalCount)
-                    assertEq(token.ownerOf(tokenIds[i]), dst);
-                else
-                    assertEq(token.ownerOf(tokenIds[i]), address(src));
-            }
-        }
-    }
-
-    function testSafeTransferFrom(
-        address dst,
-        uint256[] calldata tokenIds,
-        uint8 approvalCount,
-        bytes memory data
-    ) public {
-        // dst must approve this for more than tokenIds.length
-        if (tokenIds.length < approvalCount) return;
-        if(dst == address(0)) return;
-
-        ERC721User src = new ERC721User(token);
-
-        for (uint256 i = 0; i < tokenIds.length; i++) {
-            token.mint(address(src), tokenIds[i]);
-        }
-
-        for (uint256 i = 0; i < approvalCount; i++) {
-            src.approve(address(this), tokenIds[i]);
-            token.safeTransferFrom(address(src), dst, tokenIds[i], data);
-        }
-
-        assertEq(token.totalSupply(), tokenIds.length);
-
-        //uint256 app = address(src) == msg.sender || approvals == type(uint256).max ? approvals : approvals - tokenIds;
-        //assertEq(token.allowance(address(src), msg.sender), app);
-
-        if (address(src) == dst) {
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                assertEq(token.ownerOf(tokenIds[i]), address(src));
-            }
-        } else {
-            assertEq(token.balanceOf(address(src)), tokenIds.length - approvalCount);
-            for (uint256 i = 0; i < tokenIds.length; i++) {
-                if(i < approvalCount)
-                    assertEq(token.ownerOf(tokenIds[i]), dst);
-                else
-                    assertEq(token.ownerOf(tokenIds[i]), address(src));
-            }
         }
     }
 }

--- a/src/test/utils/mocks/MockERC721.sol
+++ b/src/test/utils/mocks/MockERC721.sol
@@ -4,14 +4,13 @@ pragma solidity >=0.8.0;
 import {ERC721} from "../../../tokens/ERC721.sol";
 
 contract MockERC721 is ERC721 {
-    constructor(string memory _name, string memory _symbol) ERC721(_name, _symbol) {}
+    constructor(string memory _name, string memory _symbol, string memory _baseURI) ERC721(_name, _symbol, _baseURI) {}
 
     function mint(
         address to,
-        uint256 tokenId,
-        string calldata tokenURI
+        uint256 tokenId
     ) external {
-        _mint(to, tokenId, tokenURI);
+        _mint(to, tokenId);
     }
 
     function burn(uint256 tokenId) external {

--- a/src/test/utils/users/ERC721User.sol
+++ b/src/test/utils/users/ERC721User.sol
@@ -50,4 +50,13 @@ contract ERC721User {
     ) public {
         token.safeTransferFrom(from, to, tokenId, data);
     }
+
+    function onERC721Received(
+        address operator,
+        address from,
+        uint256 tokenId,
+        bytes calldata data
+    ) external returns (bytes4) {
+        return 0x150b7a02;
+    }
 }

--- a/src/tokens/ERC721.sol
+++ b/src/tokens/ERC721.sol
@@ -22,6 +22,8 @@ abstract contract ERC721 {
 
     string public symbol;
 
+    string public baseURI;
+
     /*///////////////////////////////////////////////////////////////
                             ERC-721 STORAGE
     //////////////////////////////////////////////////////////////*/
@@ -31,8 +33,6 @@ abstract contract ERC721 {
     mapping(address => uint256) public balanceOf;
 
     mapping(uint256 => address) public ownerOf;
-
-    mapping(uint256 => string) public tokenURI;
 
     mapping(uint256 => address) public getApproved;
 
@@ -60,9 +60,10 @@ abstract contract ERC721 {
                             CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
     
-    constructor(string memory _name, string memory _symbol) {
+    constructor(string memory _name, string memory _symbol, string memory _baseURI) {
         name = _name;
         symbol = _symbol;
+        baseURI = _baseURI;
         
         INITIAL_CHAIN_ID = block.chainid;
         INITIAL_DOMAIN_SEPARATOR = computeDomainSeparator();
@@ -174,6 +175,10 @@ abstract contract ERC721 {
         }
     }
 
+    function tokenURI(uint256 tokenId) public view virtual returns (string memory) {
+        return string(abi.encodePacked(baseURI, tokenId));
+    }
+
     /*///////////////////////////////////////////////////////////////
                             EIP-2612-LIKE LOGIC
     //////////////////////////////////////////////////////////////*/
@@ -269,8 +274,7 @@ abstract contract ERC721 {
     
     function _mint(
         address to, 
-        uint256 tokenId, 
-        string memory tokenURI_
+        uint256 tokenId
     ) internal virtual { 
         require(ownerOf[tokenId] == address(0), "ALREADY_MINTED");
   
@@ -284,8 +288,6 @@ abstract contract ERC721 {
         }
         
         ownerOf[tokenId] = to;
-        
-        tokenURI[tokenId] = tokenURI_;
         
         emit Transfer(address(0), to, tokenId); 
     }
@@ -304,8 +306,6 @@ abstract contract ERC721 {
         }
         
         delete ownerOf[tokenId];
-        
-        delete tokenURI[tokenId];
         
         emit Transfer(owner, address(0), tokenId); 
     }


### PR DESCRIPTION
Hey, the tests were not running at all, not only because they were set to symbolic execution, but also because much of the ERC20 logic wasn't correctly mapped onto ERC721. Now they work, but I'm not sure if they are adequate to pull into the main branch. I still have some concerns that I wanted to look into over the weekend, mainly about the effects of transfers to `address(0)`.

Also, I changed the tokenURI functionality to match what most projects use today - concatenating a url to a tokenID. This saves us the massive storage that the map would have taken up and just gives us a view function that whatever frontend calls to resolve the metadata